### PR TITLE
Make gui components floatable and minimizable

### DIFF
--- a/cmapmainwindow.cpp
+++ b/cmapmainwindow.cpp
@@ -2,6 +2,8 @@
 #include "ui_cmapmainwindow.h"
 #include "cdatawarehouse.h"
 #include <QFileDialog>
+#include <QTableWidget>
+#include <QHeaderView>
 
 CMapMainWindow::CMapMainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -11,6 +13,30 @@ CMapMainWindow::CMapMainWindow(QWidget *parent) :
     ui->widgetMapCanvas->Initialize();
     setWindowTitle("Radar Display");
 
+    // Create floating/minimizable docks for controls and track table
+    m_dockControls = new QDockWidget("Controls", this);
+    m_dockControls->setObjectName("dockControls");
+    m_dockControls->setFeatures(QDockWidget::DockWidgetFloatable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetClosable);
+    m_dockControls->setWidget(ui->widget_TextualControl);
+    addDockWidget(Qt::RightDockWidgetArea, m_dockControls);
+
+    m_dockTracks = new QDockWidget("Tracks", this);
+    m_dockTracks->setObjectName("dockTracks");
+    m_dockTracks->setFeatures(QDockWidget::DockWidgetFloatable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetClosable);
+    m_dockTracks->setWidget(ui->tableWidget);
+    addDockWidget(Qt::RightDockWidgetArea, m_dockTracks);
+
+    // Make docks tabbed for cleaner UI when docked on same edge
+    tabifyDockWidget(m_dockControls, m_dockTracks);
+    m_dockControls->raise();
+
+    // Extend styles to docks for a cohesive, attractive look
+    QString dockStyle =
+        "QDockWidget { border: 1px solid #00B8D4; background-color: #050D1A; }"
+        "QDockWidget::title { background: #00B8D4; color: white; padding: 6px; }";
+    this->setStyleSheet(this->styleSheet() + dockStyle);
+
+    // Initialize the table rows/items
     ui->tableWidget->setRowCount(100);
     for ( int i = 0; i < ui->tableWidget->rowCount(); i++ ) {
         for ( int j = 0; j < ui->tableWidget->columnCount(); j++ ) {
@@ -28,7 +54,7 @@ CMapMainWindow::CMapMainWindow(QWidget *parent) :
     _m_updateTimer.start(1000);
 
 
-    ui->widget_TextualControl->setVisible(false);
+    m_dockControls->hide();
     connect(ui->widgetMapCanvas, SIGNAL(signalMouseRead(QString)), this, SLOT(slotMouseRead(QString)));
 }
 
@@ -41,7 +67,10 @@ void CMapMainWindow::keyPressEvent(QKeyEvent *event)
 {
     switch (event->key()) {
     case Qt::Key_F:
-        ui->widget_TextualControl->setVisible(!ui->widget_TextualControl->isVisible());
+        m_dockControls->setVisible(!m_dockControls->isVisible());
+        break;
+    case Qt::Key_T:
+        m_dockTracks->setVisible(!m_dockTracks->isVisible());
         break;
     case Qt::Key_H:
         ui->widgetMapCanvas->mapHome();;;

--- a/cmapmainwindow.h
+++ b/cmapmainwindow.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QTimer>
+#include <QDockWidget>
 
 namespace Ui {
 class CMapMainWindow;
@@ -33,6 +34,8 @@ private slots:
 private:
     Ui::CMapMainWindow *ui;
     QTimer _m_updateTimer;
+    QDockWidget *m_dockControls;
+    QDockWidget *m_dockTracks;
 };
 
 #endif // CMAPMAINWINDOW_H


### PR DESCRIPTION
Convert the control panel and track table into floatable and minimizable QDockWidgets with custom styling and key toggles to improve GUI flexibility and attractiveness.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b0c93cb-1a61-48e8-a3c4-3b63013d64ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b0c93cb-1a61-48e8-a3c4-3b63013d64ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

