### PR TITLE
Create rich qml ui with visible controls

### DIFF
--- a/cmapmainwindow.cpp
+++ b/cmapmainwindow.cpp
@@ -4,6 +4,8 @@
 #include <QFileDialog>
 #include <QTableWidget>
 #include <QHeaderView>
+#include <QQmlContext>
+#include <QUrl>
 
 CMapMainWindow::CMapMainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -25,6 +27,16 @@ CMapMainWindow::CMapMainWindow(QWidget *parent) :
     m_dockTracks->setFeatures(QDockWidget::DockWidgetFloatable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetClosable);
     m_dockTracks->setWidget(ui->tableWidget);
     addDockWidget(Qt::RightDockWidgetArea, m_dockTracks);
+
+    // Qt Quick dashboard dock (rich UI)
+    m_quickWidget = new QQuickWidget(this);
+    m_quickWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+    m_quickWidget->setSource(QUrl("qrc:/qml/MainView.qml"));
+    m_dockQuick = new QDockWidget("Dashboard", this);
+    m_dockQuick->setObjectName("dockQuick");
+    m_dockQuick->setFeatures(QDockWidget::DockWidgetFloatable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetClosable);
+    m_dockQuick->setWidget(m_quickWidget);
+    addDockWidget(Qt::BottomDockWidgetArea, m_dockQuick);
 
     // Make docks tabbed for cleaner UI when docked on same edge
     tabifyDockWidget(m_dockControls, m_dockTracks);
@@ -54,7 +66,13 @@ CMapMainWindow::CMapMainWindow(QWidget *parent) :
     _m_updateTimer.start(1000);
 
 
-    m_dockControls->hide();
+    // Ensure controls and tracks docks are visible on startup
+    m_dockControls->show();
+    m_dockTracks->show();
+    m_dockQuick->show();
+
+    // Enable the table for interaction/visibility
+    ui->tableWidget->setEnabled(true);
     connect(ui->widgetMapCanvas, SIGNAL(signalMouseRead(QString)), this, SLOT(slotMouseRead(QString)));
 }
 

--- a/cmapmainwindow.h
+++ b/cmapmainwindow.h
@@ -4,6 +4,7 @@
 #include <QMainWindow>
 #include <QTimer>
 #include <QDockWidget>
+#include <QQuickWidget>
 
 namespace Ui {
 class CMapMainWindow;
@@ -36,6 +37,8 @@ private:
     QTimer _m_updateTimer;
     QDockWidget *m_dockControls;
     QDockWidget *m_dockTracks;
+    QDockWidget *m_dockQuick;
+    QQuickWidget *m_quickWidget;
 };
 
 #endif // CMAPMAINWINDOW_H

--- a/main.cpp
+++ b/main.cpp
@@ -11,6 +11,7 @@
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+    QQuickStyle::setStyle("Material");
     QgsApplication::initQgis();
 
     qDebug()<<"RADAR DISPLAY";


### PR DESCRIPTION
Integrate a Qt Quick dashboard, set Material style, and ensure controls, tracks, and table are visible at startup to enrich the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-93e1b420-d816-46bf-9cd2-6b5ab0e14ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-93e1b420-d816-46bf-9cd2-6b5ab0e14ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

